### PR TITLE
Styling: Updating font styling to match Figma (DM Sans)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,20 +1,14 @@
 import * as React from "react";
 import { HeroUIProvider } from "@heroui/react";
 import type { Metadata } from "next";
-import localFont from "next/font/local";
+// import localFont from "next/font/local";
+import { DM_Sans } from "next/font/google"; // https://nextjs.org/docs/app/getting-started/fonts#google-fonts
+// "Next/font/google Fonts are included stored as static assets and served from the same domain as your deployment, meaning no requests are sent to Google by the browser when the user visits your site"
 import "./globals.css";
 import Header from "../components/Header";
 
-const geistSans = localFont({
-  src: "./fonts/GeistVF.woff",
-  variable: "--font-geist-sans",
-  weight: "100 900",
-});
-const geistMono = localFont({
-  src: "./fonts/GeistMonoVF.woff",
-  variable: "--font-geist-mono",
-  weight: "100 900",
-});
+const dmSans = DM_Sans({ subsets: ["latin"], variable: "--font-dm-sans" });
+// variable "--font-dm-sans" =  a custom css property we created so we can setup this font in Tailwindcss's config
 
 export const metadata: Metadata = {
   title: "Create Next App",
@@ -28,9 +22,31 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className={` ${dmSans.variable} font-sans antialiased`}>
+        {/* Step 1. body className={` ${dmSans.variable...}`} === exposes (adds) the css variable "--font-dm-sans" to the DOM,
+         so tailwindcss can see and use it, if its setup up within tailwindcss.config.js (the setup in the config: fontFamily: { sans: ["var(--font-dm-sans)"],},)
+         Step 2. font-sans === tells Tailwindcss to globally USE the value of that css variable
+        
+        
+        why dmSans.className or dmSans.variable? 
+         When we call DM_Sans({ subsets: ["latin"], variable: "--font-dm-sans" }) we're getting an object back
+         ex: {
+         className: "font-dm-sans_abcafafdasdf1133", <==nextJS automatically creating a css class for that font
+         variable: "--font-dm-sans" <=== a custom css property we created so we can setup this font in Tailwindcss's config
+          }
+
+          dmSans.className = we're passing the unique css class that next.js automatically generated
+          dmSans.variable = we're passing the unique css variable that we made in the DM_Sans() setup to tailwindcss.config ("--font-dm-sans"). We then pass it to tailwindcss by referencing that variable in the fontFamily config inside tailwind.config.js
+
+          Either of the above work. 
+          dmSans.variable is a bit cleaner:
+          - because we'll see font-dm-sans instead of the long custom css that Next.JS made "font-dm-sans_abcafafdasdf1133"
+          - Putting it in tailwind's config makes it easier to keep track of themes
+
+          Using dm.Sans would not work, because react would try to return the entire object "[object object] antialiased"
+
+          Special note: if we make another layout, we'd have to import DM_Sans and pass it to that layouts body as well like we did with this root layout, so tailwindCSS can "see" it for that other layout's pages
+         */}
         <HeroUIProvider>
           <Header />
           {children}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,12 @@ import type { Metadata } from "next";
 // import localFont from "next/font/local";
 import { DM_Sans } from "next/font/google"; // https://nextjs.org/docs/app/getting-started/fonts#google-fonts
 // "Next/font/google Fonts are included stored as static assets and served from the same domain as your deployment, meaning no requests are sent to Google by the browser when the user visits your site"
+// it improves performance:
+// 1. only downloads the font weights the app uses, not the entire library. So the page loads faster.
+// 2. no DNS lookups since its bundled in our app
+// 3. no layout shift, since the fonts load immediately so there is no flash of fallback text
+// improves privacy
+// 1. user's browser won't ping google's servers for the font data
 import "./globals.css";
 import Header from "../components/Header";
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,7 +3,7 @@ import { HeroUIProvider } from "@heroui/react";
 import type { Metadata } from "next";
 // import localFont from "next/font/local";
 import { DM_Sans } from "next/font/google"; // https://nextjs.org/docs/app/getting-started/fonts#google-fonts
-// "Next/font/google Fonts are included stored as static assets and served from the same domain as your deployment, meaning no requests are sent to Google by the browser when the user visits your site"
+// "Next/font/google Fonts are included stored as static assets and served from the same domain as the deployment, meaning no requests are sent to Google by the browser when the user visits your site"
 // it improves performance:
 // 1. only downloads the font weights the app uses, not the entire library. So the page loads faster.
 // 2. no DNS lookups since its bundled in our app

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,6 +21,9 @@ const config: Config = {
         // #62748e" light gray
         // "" is necessary with - because otherwise JS/TS interprets it as subtract sign and gets confused
       },
+      fontFamily: {
+        sans: ["var(--font-dm-sans)"],
+      },
     },
   },
   plugins: [heroui()],


### PR DESCRIPTION
## Description
Updated the font styling to match the font used in figma: DM Sans

## Screenshots/Videos
<!-- Drag and drop images/videos here -->

Before:
<img width="926" height="850" alt="image" src="https://github.com/user-attachments/assets/7e9d1236-17f7-481a-a5ca-5830022c9961" />
After:
<img width="908" height="611" alt="image" src="https://github.com/user-attachments/assets/027d28fa-43ca-4f91-8da9-7ef8511795a0" />


## How to Test
Steps to reproduce or test:
1.  Inspect text element
2. In filter styles type font, and you'll see Dm Sans
<img width="246" height="294" alt="image" src="https://github.com/user-attachments/assets/aeae764d-2ae2-4dda-b8c1-ebd35290786e" />

## Special Notes:
If we make another layout, we'd have to import DM_Sans and pass it to that layouts body as well like we did with this root layout, so tailwindCSS can "see" it for that other layout's pages

I added notes to explain the code's logic, but towards the end of the program we'll likely want to remove these notes

