### PR TITLE
Bug Fix: Clearing Stale Session Cookies To Avoid Supabase Call Failures & Improved Redirect Logic

### DIFF
--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -27,23 +27,10 @@ export default function AuthCallback() {
     const handleRedirect = () => {
       if (hasRedirected) return;
       hasRedirected = true;
-      const redirectPathFirstCheck = localStorage.getItem("redirectPath");
-
-      //  redirectPathFirstCheck will be either something from local storage "/providers/lawnandgarden/bobsgardening" or null
-      if (!redirectPathFirstCheck) {
-        // if redirectPathFirstCheck is null, this means it didn't find anything in localStorage!
-        // Wait and retry once before defaulting to "/" because certain browsers like chrome might having timing issues
-        setTimeout(() => {
-          const redirectPathSecondCheck =
-            localStorage.getItem("redirectPath") || "/";
-
-          localStorage.removeItem("redirectPath");
-          router.replace(redirectPathSecondCheck);
-        }, 50);
-      } else {
-        localStorage.removeItem("redirectPath");
-        router.replace(redirectPathFirstCheck);
-      }
+      const match = document.cookie.match(/redirectPath=([^;]+)/);
+      const path = match ? decodeURIComponent(match[1]) : "/";
+      document.cookie = "redirectPath=; Max-Age=0; path=/"; // deleting redirect cookie
+      router.replace(path);
     };
 
     const urlParams = new URLSearchParams(window.location.search);

--- a/app/auth/callback/page.tsx
+++ b/app/auth/callback/page.tsx
@@ -23,6 +23,29 @@ export default function AuthCallback() {
     // this prevents them from getting stuck forever on "Finishing signing you in..."
     // since Supabase never receives valid tokens to process.
 
+    let hasRedirected = false;
+    const handleRedirect = () => {
+      if (hasRedirected) return;
+      hasRedirected = true;
+      const redirectPathFirstCheck = localStorage.getItem("redirectPath");
+
+      //  redirectPathFirstCheck will be either something from local storage "/providers/lawnandgarden/bobsgardening" or null
+      if (!redirectPathFirstCheck) {
+        // if redirectPathFirstCheck is null, this means it didn't find anything in localStorage!
+        // Wait and retry once before defaulting to "/" because certain browsers like chrome might having timing issues
+        setTimeout(() => {
+          const redirectPathSecondCheck =
+            localStorage.getItem("redirectPath") || "/";
+
+          localStorage.removeItem("redirectPath");
+          router.replace(redirectPathSecondCheck);
+        }, 50);
+      } else {
+        localStorage.removeItem("redirectPath");
+        router.replace(redirectPathFirstCheck);
+      }
+    };
+
     const urlParams = new URLSearchParams(window.location.search);
     const hasAuthCode =
       urlParams.has("code") || urlParams.has("error_description");
@@ -38,27 +61,9 @@ export default function AuthCallback() {
         "signin failed, recheck your url. No valid authentication info was found. Redirecting...",
       );
       setTimeout(() => {
-        router.replace("/");
+        handleRedirect();
       }, 1000);
     }
-
-    const handleRedirect = () => {
-      const redirectPathFirstCheck = localStorage.getItem("redirectPath");
-      //  redirectPathFirstCheck will be either something from local storage "/providers/lawnandgarden/bobsgardening" or null
-      if (!redirectPathFirstCheck) {
-        // if redirectPathFirstCheck is null, this means it didn't find anything in localStorage!
-        // Wait and retry once before defaulting to "/" because certain browsers like chrome might having timing issues
-        setTimeout(() => {
-          const redirectPathSecondCheck =
-            localStorage.getItem("redirectPath") || "/";
-          localStorage.removeItem("redirectPath");
-          router.replace(redirectPathSecondCheck);
-        }, 50);
-      } else {
-        localStorage.removeItem("redirectPath");
-        router.replace(redirectPathFirstCheck);
-      }
-    };
 
     const {
       data: { subscription },

--- a/components/GoogleSignInButton.tsx
+++ b/components/GoogleSignInButton.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect } from "react";
+import React from "react";
 import supabaseClient from "@/lib/supabase";
 
 export default function GoogleSignInButton() {
@@ -13,6 +13,15 @@ export default function GoogleSignInButton() {
     // so the window object is available, avoiding hydration errors
 
     if (typeof window === "undefined") return;
+
+    localStorage.setItem("redirectPath", window.location.pathname);
+    console.log("Origin:", window.location.origin);
+
+    // lets make sure we're entirely signed out for a fresh log in
+    // this will avoid errors with supabase accidently using an invalid old session for api calls
+    // auth.signOut logs out of client
+    await supabaseClient.auth.signOut({ scope: "global" });
+    // auth.signInWithOAuth logs out on server
 
     const result = await supabaseClient.auth.signInWithOAuth({
       provider: "google",
@@ -47,14 +56,6 @@ export default function GoogleSignInButton() {
     if (result.error) console.error("Login failed:", result.error);
     // supabase handles the session, and stores it in localStorage.
   };
-
-  useEffect(() => {
-    // Now safe to access window and localStorage
-    if (typeof window !== "undefined") {
-      localStorage.setItem("redirectPath", window.location.pathname);
-      console.log("Origin:", window.location.origin);
-    }
-  }, []); // Empty dependency array ensures this runs once after mount
 
   return (
     <button type="button" onClick={handleLoginWithSupabase}>

--- a/components/GoogleSignInButton.tsx
+++ b/components/GoogleSignInButton.tsx
@@ -14,7 +14,7 @@ export default function GoogleSignInButton() {
 
     if (typeof window === "undefined") return;
 
-    localStorage.setItem("redirectPath", window.location.pathname);
+    document.cookie = `redirectPath=${window.location.pathname}; path=/; max-age=300`;
     console.log("Origin:", window.location.origin);
 
     // lets make sure we're entirely signed out for a fresh log in


### PR DESCRIPTION
## Description

Solved one edge case, partially solved a second bug.

### Problem 1

**Problem 1:** Edge case where if a user logins in, and then decides to login again, the old session cookies will cause issues when calling Supabase. For example, it will start as a valid auth/callback?code=something url and then become an invalid auth/callback)

Fix: When a user clicks logged in, they'll be logged out first (if they aren't logged in, this will do nothing). This ensures that any stale session cookies in the server and browser are cleared. 

Although in the future we'd only show the login button if the user is not signed in, there is now an extra safeguard for if some edge case with old session cookies. 

### Problem 2

**Problem 2**: User would be redirected to "/" instead of the previous url.

Edge case with local build where handleRedirect() would sometimes be called twice due to a race condition. Now handleDirect() can only be called once. 

### Special Note

Problem 2 is still not entirely fixed. it works locally but on deploys it always redirects to "/"

I tried switching the redirect page string it from localstorage to cookies but it still redirects to "/" instead on deploys. To be fixed in future ticket. 

## Screenshots/Videos
<!-- Drag and drop images/videos here -->

## How to Test
Steps to reproduce or test:
1 Go to /providers/lawnandgarden/lc001
2. Select an item, click continue to booking
<img width="502" height="263" alt="470194755-abaab7f7-8dce-4fcb-9443-7bbea509b55b" src="https://github.com/user-attachments/assets/179f2fed-6871-43a4-a9e2-39cfb1aa9f23" />

3. Sign in with google
<img width="470" height="319" alt="470194992-a2539a6f-446b-4657-b9be-254402c37d69" src="https://github.com/user-attachments/assets/614c7871-d379-4f75-bd96-dd7f0a481f85" />

4. after you are redirected to the same page, attempt to login again

5. The 2nd login will also work

