### PR TITLE
Feature: Added Test Page to View Auth Bearer Token

### DIFF
--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -6,25 +6,28 @@ import supabase from "@/lib/supabase";
 export default function ShowBearerToken() {
   useEffect(() => {
     const fetchToken = async () => {
-      const {
-        data: { session },
-        error,
-      } = await supabase.auth.getSession();
+      try {
+        const {
+          data: { session },
+          error,
+        } = await supabase.auth.getSession();
 
-      if (error) {
-        console.error("Error fetching session:", error);
-        return;
-      }
+        if (error) {
+          console.error("Error fetching session:", error);
+          return;
+        }
 
-      const token = session?.access_token;
+        const token = session?.access_token;
 
-      if (token) {
-        console.log(" Bearer Token:", token);
-      } else {
-        console.warn("No token found. User may not be signed in.");
+        if (token) {
+          console.log(" Bearer Token:", token);
+        } else {
+          console.warn("No token found. User may not be signed in.");
+        }
+      } catch (err) {
+        console.error("Error fetching token:", err);
       }
     };
-
     fetchToken();
   }, []);
 

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect } from "react";
+import supabase from "@/lib/supabase";
+
+export default function ShowBearerToken() {
+  useEffect(() => {
+    const fetchToken = async () => {
+      const {
+        data: { session },
+        error,
+      } = await supabase.auth.getSession();
+
+      if (error) {
+        console.error("Error fetching session:", error);
+        return;
+      }
+
+      const token = session?.access_token;
+
+      if (token) {
+        console.log(" Bearer Token:", token);
+      } else {
+        console.warn("No token found. User may not be signed in.");
+      }
+    };
+
+    fetchToken();
+  }, []);
+
+  return <p>Check the console for the Bearer token </p>;
+}

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -4,7 +4,8 @@ import { useEffect, useState } from "react";
 import supabase from "@/lib/supabase";
 
 export default function ShowBearerToken() {
-  const [stateToken, setStateToken] = useState(null);
+  const [stateToken, setStateToken] = useState<undefined | string>(undefined);
+  const [copied, setCopied] = useState(false);
   useEffect(() => {
     const fetchToken = async () => {
       try {
@@ -33,10 +34,41 @@ export default function ShowBearerToken() {
     fetchToken();
   }, []);
 
+  const handleCopy = async () => {
+    if (!stateToken) return;
+    try {
+      await navigator.clipboard.writeText(stateToken);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000); // Reset after 2s
+    } catch (err) {
+      console.error("Failed to copy token:", err);
+    }
+  };
+
   return (
-    <p>
-      Check the console for the Bearer token or view here:{" "}
-      {stateToken || "No token found. User may not be signed in."}
-    </p>
+    <div>
+      <p>
+        Check the console for the Bearer token or view here:{" "}
+        {stateToken && "token found!"}{" "}
+        {!stateToken && "No token found. User may not be signed in."}
+      </p>
+      {stateToken && (
+        <button
+          type="button"
+          onClick={handleCopy}
+          style={{
+            marginTop: "0.5rem",
+            padding: "0.4rem 0.8rem",
+            backgroundColor: copied ? "#4ade80" : "#2563eb",
+            color: "#fff",
+            border: "none",
+            borderRadius: "4px",
+            cursor: "pointer",
+          }}
+        >
+          {copied ? "Copied!" : "Copy Token"}
+        </button>
+      )}
+    </div>
   );
 }

--- a/app/test/page.tsx
+++ b/app/test/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import supabase from "@/lib/supabase";
 
 export default function ShowBearerToken() {
+  const [stateToken, setStateToken] = useState(null);
   useEffect(() => {
     const fetchToken = async () => {
       try {
@@ -18,6 +19,7 @@ export default function ShowBearerToken() {
         }
 
         const token = session?.access_token;
+        setStateToken(token);
 
         if (token) {
           console.log(" Bearer Token:", token);
@@ -31,5 +33,10 @@ export default function ShowBearerToken() {
     fetchToken();
   }, []);
 
-  return <p>Check the console for the Bearer token </p>;
+  return (
+    <p>
+      Check the console for the Bearer token or view here:{" "}
+      {stateToken || "No token found. User may not be signed in."}
+    </p>
+  );
 }


### PR DESCRIPTION
## Description
Added a test page to easily grab the token for testing purposes. Supabase splits the session in 2 files, so we can't just grab the token from dev tools.

## Screenshots/Videos
<!-- Drag and drop images/videos here -->

## How to Test
Steps to reproduce or test:
1.  after signing in go to /test
2. In the console and the screen you'll see a "copy token" button, if you click on it, it will copy the token to your clipboard
<img width="1035" height="796" alt="image" src="https://github.com/user-attachments/assets/7199da6d-99b5-4d31-9590-70a259b0c451" />

3. after signing out, got to /test. In the console and the screen you'll see a warning that there is not token
<img width="816" height="650" alt="image" src="https://github.com/user-attachments/assets/bcbc80df-6c0c-4400-b9eb-700ac108ac73" />
