### PR TITLE
Feat: Finishing Provider Flow

### DIFF
--- a/components/stripe/StripeCheckoutPage.tsx
+++ b/components/stripe/StripeCheckoutPage.tsx
@@ -163,7 +163,6 @@ function CheckoutForm({ clientSecret }: CheckoutOutFormType) {
         },
         {
           onSuccess: (data) => {
-            console.log(data);
             const bookingId = data.id;
             setMessage("Booking successfully created!");
             queryClient.invalidateQueries({ queryKey: ["bookings"] });


### PR DESCRIPTION
## Description
Finished the booking flow. I grabbed the booking id from the returned data, and passed that to the route: (`/booking-confirmation/${bookingId}`)

## How to Test
Steps to reproduce or test:
1. Go though the full checkout flow
2. on the confirmation screen you'll see it will match the service, provider and cost you selected
<img width="535" height="577" alt="image" src="https://github.com/user-attachments/assets/7857fc45-43ce-4116-8151-7da9e843285a" />

It will close these issues: 
https://github.com/dsd-cohort-team-corgi/backend/issues/40
https://github.com/dsd-cohort-team-corgi/backend/issues/35
