### PR TITLE
UI Improvements: Scrollable Time Slots

### DIFF
--- a/components/Calendar/AvailableTimeSlots.tsx
+++ b/components/Calendar/AvailableTimeSlots.tsx
@@ -49,7 +49,7 @@ export default function AvailableTimeSlots({
         type="button"
         onPress={handleUp}
         disabled={startIndex === 0}
-        className=" w-full"
+        className=" w-full disabled:bg-slate-600"
         startContent={<ArrowBigUp />}
       />
       <ul className="flex w-full flex-col gap-y-3">
@@ -72,7 +72,7 @@ export default function AvailableTimeSlots({
       </ul>
       <StyledAsButton
         onPress={handleDown}
-        className="w-full"
+        className="w-full  disabled:bg-slate-600"
         disabled={startIndex + pageSize >= availableTimeSlots.length}
         startContent={<ArrowBigDown />}
       />

--- a/components/buttons/CheckoutButton.tsx
+++ b/components/buttons/CheckoutButton.tsx
@@ -117,7 +117,7 @@ export default function CheckoutButton({
         onOpenChange={completeProfileOnOpenChange}
       /> */}
       <StyledAsButton
-        className={`mb-4 mt-6 block px-0 disabled:bg-gray-500 disabled:text-black h-14 ${className}`}
+        className={`mb-4 mt-6 block px-0 disabled:bg-gray-500 disabled:text-white h-14 ${className}`}
         label={text || "Continue to Booking"}
         onPress={() => handleContinueToBooking()}
         disabled={disabled}


### PR DESCRIPTION
## Description

Add scrolling funtionality to the timeslots

## Screenshots/Videos

Before:
<img width="655" height="805" alt="image" src="https://github.com/user-attachments/assets/7aec4c6c-3a53-43aa-b837-39b97b0ee7d0" />

After:
<img width="528" height="515" alt="image" src="https://github.com/user-attachments/assets/4fdcb407-0e0a-48a8-ae43-c0569eec907f" />


## How to Test

Steps to reproduce or test:

1. go to the page, click up or down, and you'll move up and down the list


## other

Changed button color for continue to booking when disabled
<img width="528" height="384" alt="image" src="https://github.com/user-attachments/assets/8be6eed2-bdec-40e4-9537-90f9350cc5e5" />



