### PR TITLE
edit: styles on bumi modal to allow for scrolling

### DIFF
--- a/components/BumiModal.tsx
+++ b/components/BumiModal.tsx
@@ -41,8 +41,10 @@ const ModalOverlay = styled.div<{ isOpen: boolean }>`
 
 const ModalContainer = styled.div`
   position: relative;
-  width: 800px;
   min-height: 125px;
+  width: 800px;
+  max-height: 80vh;
+  overflow-y: scroll;
   background: #23262f;
   box-shadow:
     0px 40px 64px -32px rgba(15, 15, 15, 0.1),
@@ -102,7 +104,10 @@ function BumiModal({ isOpen, onOpenChange }: BumiModalType) {
   return (
     <ModalOverlay isOpen={isOpen} onClick={onOpenChange}>
       {isOpen && (
-        <ModalContainer onClick={(e) => e.stopPropagation()}>
+        <ModalContainer
+          onClick={(e) => e.stopPropagation()}
+          className="no-scrollbar"
+        >
           <ModalHeader />
           <SpeechToText onClose={onOpenChange} />
         </ModalContainer>


### PR DESCRIPTION
## Description
changed styles on bumi modal to allow for scrolling
## Screenshots/Videos

<!-- Drag and drop images/videos here -->
<img width="983" height="774" alt="Screen Shot 2025-08-13 at 4 03 28 PM" src="https://github.com/user-attachments/assets/31ef9142-f1c6-407b-ac7c-0ef5ef340e3f" />
<img width="989" height="751" alt="Screen Shot 2025-08-13 at 4 03 36 PM" src="https://github.com/user-attachments/assets/204fdb29-eb81-4aad-b098-addd84aeb49b" />

## How to Test

Steps to reproduce or test:

1. open modal and ask bumi for a list of all lawn care providers
2. scroll down and proceed to booking. this pr does not affect logic
